### PR TITLE
Bug Fix -- Small fix for location icon not appearing on higher resolution devices

### DIFF
--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -3,12 +3,14 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { LocationSidebar } from './popups/LocationSidebar';
 import API_URL from './config';
-import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerIcon from "leaflet/dist/images/marker-icon.png";
+import markerIconRetina from "leaflet/dist/images/marker-icon-2x.png"; // Without this, it the icon will not properly display
 import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 
 // Fix Leaflet marker icons breaking in Vite builds
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
+  iconRetinaUrl: markerIconRetina,
   iconUrl: markerIcon,
   shadowUrl: markerShadow,
 });


### PR DESCRIPTION
Bug: On higher resolution devices, the Leaflet location icon was not properly displaying, and was showing a missing image.
Fix: Import marker-icon-2x.png and set it as the iconRetinaUrl for default Leaflet icons.
