### PR TITLE
Implemented simple search bar to search by study location name or location building and moved zoom control panel

### DIFF
--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { LocationSidebar } from './popups/LocationSidebar';
+import { SearchBar } from './searchbar/SearchBar';
 import API_URL from './config';
 import markerIcon from "leaflet/dist/images/marker-icon.png";
 import markerIconRetina from "leaflet/dist/images/marker-icon-2x.png"; // Without this, it the icon will not properly display
@@ -48,7 +49,7 @@ function App() {
     const zoomLevel = 15;
 
     // Init map
-    map.current = L.map(mapContainer.current,{zoomControl: false}).setView(osuCoords, zoomLevel);
+    map.current = L.map(mapContainer.current, { zoomControl: false }).setView(osuCoords, zoomLevel);
     // Add OSM tile layer (z = zoom, x = horizontal tile coordinate, y = vertical tile coordinate)
     // Values automatically updated by leaflet as the user pans and zooms
     L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -58,9 +59,9 @@ function App() {
       // Sets the number of tiles/columns kept when panning
       keepBuffer: 100
     }).addTo(map.current);
-    
+
     // Moves zoom control to the top right, as top left led to it being below our location sidebar
-    L.control.zoom({position: 'topright'}).addTo(map.current);
+    L.control.zoom({ position: 'topright' }).addTo(map.current);
   }, []);
 
   // Add location markers to map
@@ -72,7 +73,7 @@ function App() {
       locations.forEach(location => {
         if (!location.lat || !location.lng) return; //Check if there are latitude and longitude in the db
         const marker = L.marker([location.lat, location.lng]).addTo(map.current); //Create a marker and add it to the map
-        
+
         // Add click event to show location in sidebar
         marker.on('click', () => {
           setSelectedLocation(location);
@@ -81,23 +82,44 @@ function App() {
     });
   }, [locations]);
 
-  return(
+  const handleSearchResultClick = (location) => {
+    setSelectedLocation(location);
+
+    if (map.current && location.lat && location.lng) {
+      map.current.flyTo([location.lat, location.lng], 19,
+        {
+          animate: true,
+          duration: 1,
+          // Makes it take a second panning, also not sure if this is the optimal timing, we can ask beta test users!
+          easeLinearity: 0.1
+          // Honestly not entirely sure if this option is doing anything? Feels about the same to me with it set at 1 or 0.1
+          // Theoretically should make it smoother for pan and zoom using bezier curves though... so why not?
+        }
+      );
+    }
+  };
+
+  return (
     <div className="w-full h-screen flex flex-col">
       <div className="bg-linear-to-r from-orange-600 to-orange-500 p-4 shadow-lg">
         <h1 className="text-white text-3xl font-bold">Study Savior</h1>
         <p className="text-orange-100">OSU Campus Study Locations</p>
       </div>
       <div className="relative flex-1">
-        <div 
-          ref={mapContainer} 
+        <div
+          ref={mapContainer}
           className="w-full h-full"
         />
         {selectedLocation && (
-          <LocationSidebar 
-            location={selectedLocation} 
-            onClose={() => setSelectedLocation(null)} 
+          <LocationSidebar
+            location={selectedLocation}
+            onClose={() => setSelectedLocation(null)}
           />
         )}
+        <SearchBar
+          locations={locations}
+          onResultClick={handleSearchResultClick}
+        />
       </div>
     </div>
   );

--- a/frontend/popups/LocationSidebar.jsx
+++ b/frontend/popups/LocationSidebar.jsx
@@ -39,9 +39,9 @@ export function LocationSidebar({ location, onClose }) {
   const comfort = location.average_comfort_location || 0;
 
   return (
-    <div className="fixed left-4 top-24 bottom-4 w-96 bg-white rounded-lg shadow-2xl overflow-hidden flex flex-col z-1000 border-2 border-black">
+    <div className="absolute left-4 top-2.75 bottom-4 w-96 bg-white rounded-lg shadow-2xl overflow-hidden flex flex-col z-1000 border-2 border-black">
       {/* Close button */}
-      <button 
+      <button
         onClick={onClose}
         className="absolute top-2 right-2 p-1 rounded-full hover:bg-gray-200 z-10"
       >
@@ -101,7 +101,7 @@ export function LocationSidebar({ location, onClose }) {
                 </span>
               ))
             ) : (
-              <p className="text-gray-500 text-sm"><Tag/>No tags</p>
+              <p className="text-gray-500 text-sm"><Tag />No tags</p>
             )}
           </div>
         </div>
@@ -113,7 +113,7 @@ export function LocationSidebar({ location, onClose }) {
 
         {/* Review Button */}
         <div className="p-3">
-          <button 
+          <button
             className="w-full py-2 px-4 border-2 border-blue-500 text-blue-500 font-semibold rounded-full hover:bg-blue-500 hover:text-white transition-all text-sm"
             onClick={() => alert('Review feature coming soon!')}
           >

--- a/frontend/searchbar/SearchBar.jsx
+++ b/frontend/searchbar/SearchBar.jsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { Search } from 'lucide-react';
+import { MapPin } from 'lucide-react';
+
+export function SearchBar({ locations = [], onResultClick }) {
+  const [query, setQuery] = useState('');
+  const [filteredLocations, setFilteredLocations] = useState([]);
+
+  useEffect(() => {
+    // console.log("Locations prop:", locations);
+    if (!query.trim()) { // If the query is empty, show no locations
+      setFilteredLocations([]);
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      if (!Array.isArray(locations)) return;
+
+      const lowerQuery = query.toLowerCase();
+
+      // If either the 
+      const results = locations.filter(loc =>
+        loc.name_location?.toLowerCase().includes(lowerQuery) ||
+        loc.hall_location?.toLowerCase().includes(lowerQuery)
+      );
+
+      setFilteredLocations(results);
+    }, 100);
+    // Makes it wait a 100ms before populating results so they don't constantly change while you're typing
+    // Not sure if 100ms is the aesthetically optimal amount, but I figure it's not bad
+
+    // Cleanup function cancels previous timeout
+    return () => clearTimeout(timeout);
+
+  }, [query, locations]);
+
+  return ( // bg-white rounded-lg shadow-2xl overflow-hidden flex flex-col z-1000 border-2 border-black
+    <div className="absolute top-2.75 right-14 w-80 bg-white shadow-2xl rounded-lg p-3 z-1000 border-2 border-black">
+
+      {/* Search Input */}
+      <div className="flex items-center border-2 border-gray-500 rounded-lg px-2 py-1">
+        <Search size={18} className="text-gray-500 mr-2" />
+        <input
+          type="text"
+          placeholder="Search Study Locations"
+          className="w-full outline-none text-sm"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </div>
+
+      {/* Only show results if user typed something */}
+      {query.trim() && filteredLocations.length > 0 && (
+        <div className="mt-3 max-h-48 overflow-y-auto border-t pt-2">
+          {filteredLocations.map(location => (
+            <div
+              key={location.id_location}
+              onClick={() => {
+                onResultClick(location);
+                setQuery('');
+                setFilteredLocations([]);
+              }}
+              className="p-2 hover:bg-gray-100 cursor-pointer rounded text-sm"
+            >
+              <div className="flex items-center">
+                <MapPin size={18} className="text-gray-500 mr-2" />
+                <div>
+                  <div className="font-semibold">
+                    {location.name_location}
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    {location.hall_location}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Implemented simple search bar for searching study locations by name or building name. If the query is included in either study location name or building name, it will find it, but has no room for typos, as it isn't a closeness checker.
That can be implemented later, but will require most likely far more work.

Also moved the zoom control panel to the top right, as it was being hidden under the location sidebar when that appeared.